### PR TITLE
UI cleanup: remove hero image and LinkedIn link

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -21,15 +21,6 @@ import { SITE_TITLE } from '../consts';
 					></path>
 				</svg>
 			</a>
-			<a href="https://linkedin.com/in/" target="_blank">
-				<span class="sr-only">Follow on LinkedIn</span>
-				<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32">
-					<path
-						fill="currentColor"
-						d="M0 1.146C0 .513.526 0 1.175 0h13.65C15.474 0 16 .513 16 1.146v13.708c0 .633-.526 1.146-1.175 1.146H1.175C.526 16 0 15.487 0 14.854V1.146zm4.943 12.248V6.169H2.542v7.225h2.401zm-1.2-8.212c.837 0 1.358-.554 1.358-1.248-.015-.709-.52-1.248-1.342-1.248-.822 0-1.359.54-1.359 1.248 0 .694.521 1.248 1.327 1.248h.016zm4.908 8.212V9.359c0-.216.016-.432.08-.586.173-.431.568-.878 1.232-.878.869 0 1.216.662 1.216 1.634v3.865h2.401V9.25c0-2.22-1.184-3.252-2.764-3.252-1.274 0-1.845.7-2.165 1.193v.025h-.016a5.54 5.54 0 0 1 .016-.025V6.169h-2.4c.03.678 0 7.225 0 7.225h2.4z"
-					></path>
-				</svg>
-			</a>
 			<a href="/rss.xml" target="_blank">
 				<span class="sr-only">RSS Feed</span>
 				<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32">

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -123,12 +123,6 @@ const { title, description, pubDate, updatedDate, heroImage, category, tags } = 
 		<Header />
 		<main>
 			<article>
-				{heroImage && (
-					<div class="hero-image">
-						<img src={heroImage} alt={title} />
-					</div>
-				)}
-				
 				<div class="post-header">
 					<h1 class="post-title">{title}</h1>
 					<div class="post-meta">


### PR DESCRIPTION
## Summary
- Removed hero image from blog post detail pages for a cleaner look
- Removed LinkedIn social link from the header

## Test plan
- Verify blog post pages display correctly without hero image
- Confirm header displays correctly with only GitHub and RSS links

🤖 Generated with [Claude Code](https://claude.ai/code)